### PR TITLE
Support base URLs with optional query params

### DIFF
--- a/5-Create_CloudFront_SignedURL_Canned/cf_signedurl_canned.js
+++ b/5-Create_CloudFront_SignedURL_Canned/cf_signedurl_canned.js
@@ -39,8 +39,9 @@ exports.handler = async (event, data, callback) => {
   signer.update(cannedPolicy);
   let signedPolicy = signer.sign(await getKeyFromSecretsManager(), 'base64');
   signedPolicy = signedPolicy.replace(/[+=/]/g, m => replacementChars[m]);
-
-  const cfSignedUrl = `${event.baseUrl}&Expires=${expiration}&Signature=${signedPolicy}&Key-Pair-Id=${process.env.amazonCloudFrontKeyPairId}`;
+  
+  const paramDelimiter = (event.baseUrl.indexOf('?') === -1) ? '?' : '&';
+  const cfSignedUrl = `${event.baseUrl}${paramDelimiter}Expires=${expiration}&Signature=${signedPolicy}&Key-Pair-Id=${process.env.amazonCloudFrontKeyPairId}`;
 
   const response = {
     cfSignedUrl: cfSignedUrl

--- a/6-Create_CloudFront_SignedURL_Custom/cf_signedurl_custom.js
+++ b/6-Create_CloudFront_SignedURL_Custom/cf_signedurl_custom.js
@@ -47,7 +47,8 @@ exports.handler = async (event, data, callback) => {
   let signedPolicy = signer.sign(await getKeyFromSecretsManager(), 'base64');
   signedPolicy = signedPolicy.replace(/[+=/]/g, m => replacementChars[m]);
 
-  const cfSignedUrl = `${event.baseUrl}&Policy=${encodedPolicy}&Signature=${signedPolicy}&Key-Pair-Id=${process.env.amazonCloudFrontKeyPairId}`;
+  const paramDelimiter = (event.baseUrl.indexOf('?') === -1) ? '?' : '&';
+  const cfSignedUrl = `${event.baseUrl}${paramDelimiter}Policy=${encodedPolicy}&Signature=${signedPolicy}&Key-Pair-Id=${process.env.amazonCloudFrontKeyPairId}`;
 
   const response = {
     cfSignedUrl: cfSignedUrl


### PR DESCRIPTION
Thank you very much for this walk-through! I needed to implement this exact pattern, today. Though I stumbled while trying to test on a `baseUrl` that didn't contain a parameter. I would like to assist the next person that finds this project.

**Description of changes**:
The example lambda event handlers currently build a query string which presumes that at least one parameter exists on the `baseUrl`. This change will now support the situation where `baseUrl` has no parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
